### PR TITLE
Add multi-device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## NitroSense™ "clone" for linux ```AN515-46```
-### Controls fan speed, gaming modes and undervolting on Linux. This application is intended for Acer Nitro 5 AN515-46 model (contact me if you want to know how to port it to another one).
+### Controls fan speed, gaming modes and undervolting on Linux. This application is intended for Acer Nitro 5 AN515-46 model (contact me if you want me to add support for another one).
 ![image](https://github.com/user-attachments/assets/6bb2a8e8-4816-4b86-ac8d-e882fb464f15)
 ![image](https://github.com/user-attachments/assets/9b91a2f9-94e8-4f72-bb1b-cb8978ae20cd)
 

--- a/core/device_regs.py
+++ b/core/device_regs.py
@@ -1,4 +1,6 @@
 import enum
+import sys
+from dmidecode import DMIDecode
 
 ## ------------------------------##
 ## --Nitro EC Register Class--##
@@ -9,50 +11,60 @@ import enum
 # unexpected behavior or damage to the laptop.
 # Use at your own risk.
 # ---------------------------------##
-class ECS(enum.Enum):
-    GPU_FAN_MODE_CONTROL = "0x21"   # Address to set GPU fan mode
-    GPU_AUTO_MODE = "0x10"
-    GPU_TURBO_MODE = "0x20"
-    GPU_MANUAL_MODE = "0x30"
-    GPU_MANUAL_SPEED_CONTROL = "0x3A"   # Address to set GPU fan speed
 
-    CPU_FAN_MODE_CONTROL = "0x22"   # Address to set CPU fan mode
-    CPU_AUTO_MODE = "0x04"
-    CPU_TURBO_MODE = "0x08"
-    CPU_MANUAL_MODE = "0x0C"
-    CPU_MANUAL_SPEED_CONTROL = "0x37"   # Address to set CPU fan speed
+model = DMIDecode().model()
 
-    KB_30_SEC_AUTO = "0x06"     # Address to set keyboard backlight timeout
-    KB_30_AUTO_OFF = "0x00"
-    KB_30_AUTO_ON = "0x1E"
+print(f"Detected running on: {model}")
 
-    CPUFANSPEEDHIGHBITS = "0x13"
-    CPUFANSPEEDLOWBITS = "0x14"
-    GPUFANSPEEDHIGHBITS = "0x15"
-    GPUFANSPEEDLOWBITS = "0x16"
+if (model == "Nitro AN515-46"):
+    class ECS(enum.Enum):
+        GPU_FAN_MODE_CONTROL = "0x21"   # Address to set GPU fan mode
+        GPU_AUTO_MODE = "0x10"
+        GPU_TURBO_MODE = "0x20"
+        GPU_MANUAL_MODE = "0x30"
+        GPU_MANUAL_SPEED_CONTROL = "0x3A"   # Address to set GPU fan speed
 
-    CPUTEMP = "0xB0"
-    GPUTEMP = "0xB6"
-    SYSTEMP = "0xB3"
+        CPU_FAN_MODE_CONTROL = "0x22"   # Address to set CPU fan mode
+        CPU_AUTO_MODE = "0x04"
+        CPU_TURBO_MODE = "0x08"
+        CPU_MANUAL_MODE = "0x0C"
+        CPU_MANUAL_SPEED_CONTROL = "0x37"   # Address to set CPU fan speed
 
-    POWERSTATUS = "0x00"        # Address to read power status
-    POWERPLUGGEDIN = "0x01"
-    POWERUNPLUGGED = "0x00"
+        KB_30_SEC_AUTO = "0x06"     # Address to set keyboard backlight timeout
+        KB_30_AUTO_OFF = "0x00"
+        KB_30_AUTO_ON = "0x1E"
 
-    BATTERYCHARGELIMIT = "0x03" # Address to set battery charge limit
-    BATTERYLIMITON = "0x51"
-    BATTERYLIMITOFF = "0x11"
+        CPUFANSPEEDHIGHBITS = "0x13"
+        CPUFANSPEEDLOWBITS = "0x14"
+        GPUFANSPEEDHIGHBITS = "0x15"
+        GPUFANSPEEDLOWBITS = "0x16"
 
-    BATTERYSTATUS = "0xC1"      # Address to read battery status
-    BATTERYPLUGGEDINANDCHARGING = "0x02"
-    BATTERYDRAINING = "0x01"
-    BATTERYOFF = "0x00"
+        CPUTEMP = "0xB0"
+        GPUTEMP = "0xB6"
+        SYSTEMP = "0xB3"
 
-    POWEROFFUSBCHARGING = "0x08" # Address to switch USB charging on/off
-    USBCHARGINGON = "0x0F"
-    USBCHARGINGOFF = "0x1F"
+        POWERSTATUS = "0x00"        # Address to read power status
+        POWERPLUGGEDIN = "0x01"
+        POWERUNPLUGGED = "0x00"
 
-    NITROMODE = "0x2C"          # Address to change modes
-    QUIETMODE = "0x00"  
-    DEFAULTMODE = "0x01"
-    EXTREMEMODE = "0x04"
+        BATTERYCHARGELIMIT = "0x03" # Address to set battery charge limit
+        BATTERYLIMITON = "0x51"
+        BATTERYLIMITOFF = "0x11"
+
+        BATTERYSTATUS = "0xC1"      # Address to read battery status
+        BATTERYPLUGGEDINANDCHARGING = "0x02"
+        BATTERYDRAINING = "0x01"
+        BATTERYOFF = "0x00"
+
+        POWEROFFUSBCHARGING = "0x08" # Address to switch USB charging on/off
+        USBCHARGINGON = "0x0F"
+        USBCHARGINGOFF = "0x1F"
+
+        NITROMODE = "0x2C"          # Address to change modes
+        QUIETMODE = "0x00"  
+        DEFAULTMODE = "0x01"
+        EXTREMEMODE = "0x04"
+
+else:
+    print(f"Device {model} not supported!")
+    sys.exit(1)

--- a/core/device_regs.py
+++ b/core/device_regs.py
@@ -110,6 +110,7 @@ class ECS_AN515_44(enum.Enum):
 
 MODEL_TO_ECS = {
     "Nitro AN515-46": ECS_AN515_46,
+    "Nitro AN515-56": ECS_AN515_46,
     "Nitro AN515-44": ECS_AN515_44,
 }
 

--- a/core/device_regs.py
+++ b/core/device_regs.py
@@ -60,8 +60,57 @@ class ECS_AN515_46(enum.Enum):
     DEFAULTMODE = "0x01"
     EXTREMEMODE = "0x04"
 
+class ECS_AN515_44(enum.Enum):
+    GPU_FAN_MODE_CONTROL = "0x21"   # Address to set GPU fan mode
+    GPU_AUTO_MODE = "0x10"
+    GPU_TURBO_MODE = "0x20"
+    GPU_MANUAL_MODE = "0x30"
+    GPU_MANUAL_SPEED_CONTROL = "0x3A"   # Address to set GPU fan speed
+
+    CPU_FAN_MODE_CONTROL = "0x22"   # Address to set CPU fan mode
+    CPU_AUTO_MODE = "0x04"
+    CPU_TURBO_MODE = "0x08"
+    CPU_MANUAL_MODE = "0x0C"
+    CPU_MANUAL_SPEED_CONTROL = "0x37"   # Address to set CPU fan speed
+
+    KB_30_SEC_AUTO = "0x06"     # Address to set keyboard backlight timeout
+    KB_30_AUTO_OFF = "0x00"
+    KB_30_AUTO_ON = "0x1E"
+
+    CPUFANSPEEDHIGHBITS = "0x13"
+    CPUFANSPEEDLOWBITS = "0x14"
+    GPUFANSPEEDHIGHBITS = "0x15"
+    GPUFANSPEEDLOWBITS = "0x16"
+
+    CPUTEMP = "0xB0"
+    GPUTEMP = "0xB4"
+    SYSTEMP = "0xB0"
+
+    POWERSTATUS = "0x00"        # Address to read power status
+    POWERPLUGGEDIN = "0x01"
+    POWERUNPLUGGED = "0x00"
+
+    BATTERYCHARGELIMIT = "0x03" # Address to set battery charge limit
+    BATTERYLIMITON = "0x40"
+    BATTERYLIMITOFF = "0x00"
+
+    BATTERYSTATUS = "0xC1"      # Address to read battery status
+    BATTERYPLUGGEDINANDCHARGING = "0x02"
+    BATTERYDRAINING = "0x01"
+    BATTERYOFF = "0x00"
+
+    POWEROFFUSBCHARGING = "0x08" # Address to switch USB charging on/off
+    USBCHARGINGON = "0x0F"
+    USBCHARGINGOFF = "0x1F"
+
+    NITROMODE = "0x2C"          # Address to change modes
+    QUIETMODE = "0x00"  
+    DEFAULTMODE = "0x01"
+    EXTREMEMODE = "0x04"
+
 MODEL_TO_ECS = {
     "Nitro AN515-46": ECS_AN515_46,
+    "Nitro AN515-44": ECS_AN515_44,
 }
 
 model = DMIDecode().model()

--- a/core/device_regs.py
+++ b/core/device_regs.py
@@ -12,59 +12,64 @@ from dmidecode import DMIDecode
 # Use at your own risk.
 # ---------------------------------##
 
-model = DMIDecode().model()
+class ECS_AN515_46(enum.Enum):
+    GPU_FAN_MODE_CONTROL = "0x21"   # Address to set GPU fan mode
+    GPU_AUTO_MODE = "0x10"
+    GPU_TURBO_MODE = "0x20"
+    GPU_MANUAL_MODE = "0x30"
+    GPU_MANUAL_SPEED_CONTROL = "0x3A"   # Address to set GPU fan speed
 
+    CPU_FAN_MODE_CONTROL = "0x22"   # Address to set CPU fan mode
+    CPU_AUTO_MODE = "0x04"
+    CPU_TURBO_MODE = "0x08"
+    CPU_MANUAL_MODE = "0x0C"
+    CPU_MANUAL_SPEED_CONTROL = "0x37"   # Address to set CPU fan speed
+
+    KB_30_SEC_AUTO = "0x06"     # Address to set keyboard backlight timeout
+    KB_30_AUTO_OFF = "0x00"
+    KB_30_AUTO_ON = "0x1E"
+
+    CPUFANSPEEDHIGHBITS = "0x13"
+    CPUFANSPEEDLOWBITS = "0x14"
+    GPUFANSPEEDHIGHBITS = "0x15"
+    GPUFANSPEEDLOWBITS = "0x16"
+
+    CPUTEMP = "0xB0"
+    GPUTEMP = "0xB6"
+    SYSTEMP = "0xB3"
+
+    POWERSTATUS = "0x00"        # Address to read power status
+    POWERPLUGGEDIN = "0x01"
+    POWERUNPLUGGED = "0x00"
+
+    BATTERYCHARGELIMIT = "0x03" # Address to set battery charge limit
+    BATTERYLIMITON = "0x51"
+    BATTERYLIMITOFF = "0x11"
+
+    BATTERYSTATUS = "0xC1"      # Address to read battery status
+    BATTERYPLUGGEDINANDCHARGING = "0x02"
+    BATTERYDRAINING = "0x01"
+    BATTERYOFF = "0x00"
+
+    POWEROFFUSBCHARGING = "0x08" # Address to switch USB charging on/off
+    USBCHARGINGON = "0x0F"
+    USBCHARGINGOFF = "0x1F"
+
+    NITROMODE = "0x2C"          # Address to change modes
+    QUIETMODE = "0x00"  
+    DEFAULTMODE = "0x01"
+    EXTREMEMODE = "0x04"
+
+MODEL_TO_ECS = {
+    "Nitro AN515-46": ECS_AN515_46,
+}
+
+model = DMIDecode().model()
 print(f"Detected running on: {model}")
 
-if (model == "Nitro AN515-46"):
-    class ECS(enum.Enum):
-        GPU_FAN_MODE_CONTROL = "0x21"   # Address to set GPU fan mode
-        GPU_AUTO_MODE = "0x10"
-        GPU_TURBO_MODE = "0x20"
-        GPU_MANUAL_MODE = "0x30"
-        GPU_MANUAL_SPEED_CONTROL = "0x3A"   # Address to set GPU fan speed
-
-        CPU_FAN_MODE_CONTROL = "0x22"   # Address to set CPU fan mode
-        CPU_AUTO_MODE = "0x04"
-        CPU_TURBO_MODE = "0x08"
-        CPU_MANUAL_MODE = "0x0C"
-        CPU_MANUAL_SPEED_CONTROL = "0x37"   # Address to set CPU fan speed
-
-        KB_30_SEC_AUTO = "0x06"     # Address to set keyboard backlight timeout
-        KB_30_AUTO_OFF = "0x00"
-        KB_30_AUTO_ON = "0x1E"
-
-        CPUFANSPEEDHIGHBITS = "0x13"
-        CPUFANSPEEDLOWBITS = "0x14"
-        GPUFANSPEEDHIGHBITS = "0x15"
-        GPUFANSPEEDLOWBITS = "0x16"
-
-        CPUTEMP = "0xB0"
-        GPUTEMP = "0xB6"
-        SYSTEMP = "0xB3"
-
-        POWERSTATUS = "0x00"        # Address to read power status
-        POWERPLUGGEDIN = "0x01"
-        POWERUNPLUGGED = "0x00"
-
-        BATTERYCHARGELIMIT = "0x03" # Address to set battery charge limit
-        BATTERYLIMITON = "0x51"
-        BATTERYLIMITOFF = "0x11"
-
-        BATTERYSTATUS = "0xC1"      # Address to read battery status
-        BATTERYPLUGGEDINANDCHARGING = "0x02"
-        BATTERYDRAINING = "0x01"
-        BATTERYOFF = "0x00"
-
-        POWEROFFUSBCHARGING = "0x08" # Address to switch USB charging on/off
-        USBCHARGINGON = "0x0F"
-        USBCHARGINGOFF = "0x1F"
-
-        NITROMODE = "0x2C"          # Address to change modes
-        QUIETMODE = "0x00"  
-        DEFAULTMODE = "0x01"
-        EXTREMEMODE = "0x04"
-
+ECS = MODEL_TO_ECS.get(model)
+if ECS:
+    print(f"Using registers for {model}")
 else:
     print(f"Device {model} not supported!")
     sys.exit(1)

--- a/core/ecwrite.py
+++ b/core/ecwrite.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from PyQt6.QtCore import QProcess
 
 class ECWrite:
@@ -72,4 +73,4 @@ class ECWrite:
 
     def _handle_error(self, message):
         print(f"Error: {message}")
-        exit(1)
+        sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -625,7 +625,7 @@ class MainWindow(QtWidgets.QDialog, Ui_NitroSense):
         self.ECHandler.shutdown_ec()
         voltage_process.close()
         print("Exiting")
-        exit(0)
+        sys.exit(0)
 
 
 app = QtWidgets.QApplication(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+altgraph==0.17.4
+packaging==24.2
+pip==25.0.1
+py-dmidecode==0.1.3
+pyinstaller==6.12.0
+pyinstaller-hooks-contrib==2025.2
+PyQt6==6.9.0
+PyQt6-Charts==6.9.0
+PyQt6-Charts-Qt6==6.9.0
+PyQt6-Qt6==6.9.0
+PyQt6_sip==13.10.0
+setuptools==78.1.0

--- a/ui/dialog.ui
+++ b/ui/dialog.ui
@@ -110,7 +110,7 @@ QCheckBox::indicator:checked {
       <string notr="true"/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <property name="sizePolicy">
@@ -1754,6 +1754,9 @@ QCheckBox::indicator:checked {
              <number>4</number>
             </property>
             <property name="leftMargin">
+             <number>8</number>
+            </property>
+            <property name="topMargin">
              <number>8</number>
             </property>
             <property name="rightMargin">

--- a/ui/frontend.py
+++ b/ui/frontend.py
@@ -936,7 +936,7 @@ class Ui_NitroSense(object):
         self.formLayout = QtWidgets.QFormLayout()
         self.formLayout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignLeading|QtCore.Qt.AlignmentFlag.AlignLeft|QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.formLayout.setFormAlignment(QtCore.Qt.AlignmentFlag.AlignLeading|QtCore.Qt.AlignmentFlag.AlignLeft|QtCore.Qt.AlignmentFlag.AlignTop)
-        self.formLayout.setContentsMargins(8, -1, 8, -1)
+        self.formLayout.setContentsMargins(8, 8, 8, -1)
         self.formLayout.setHorizontalSpacing(40)
         self.formLayout.setVerticalSpacing(4)
         self.formLayout.setObjectName("formLayout")
@@ -1063,7 +1063,7 @@ class Ui_NitroSense(object):
         self.verticalLayout.addWidget(self.fan_control_tab)
 
         self.retranslateUi(NitroSense)
-        self.fan_control_tab.setCurrentIndex(0)
+        self.fan_control_tab.setCurrentIndex(1)
         QtCore.QMetaObject.connectSlotsByName(NitroSense)
 
     def retranslateUi(self, NitroSense):


### PR DESCRIPTION
I have a goal of at least 3 devices working

The things I need to have for each device:
- Output of `sudo dmidecode -s system-product-name` (easy part)
- Registries and memory addresses of the embedded controler

For getting the registries and addresses you'll need windows and the original NitroSense software (I can help you with that). 
The process is easy but I can't really do it remotely.

How did I do it:
YOU'LL NEED WINDOWS
Download some kinda EC (embedded controller) reader
I used [RWEverything](https://rweverything.com)
Open up the reader and open the EC editor
Open NitroSense
Change values on NitroSense and see which numbers change consistently and where
Take note of everything you want, remember to connect and disconnect power, change fan modes, change power profiles, change the manual speed of the fans etc

Use [this part of the code](https://github.com/Packss/Linux-NitroSense/blob/multi-device/core/device_regs.py) as a reference if you want, some regs and adresses will match