### PR TITLE
Add support for Nitro AN515-55

### DIFF
--- a/core/device_regs.py
+++ b/core/device_regs.py
@@ -116,6 +116,7 @@ MODEL_TO_ECS = {
     "Nitro AN515-46": ECS_AN515_46,
     "Nitro AN515-53": ECS_AN515_46,
     "Nitro AN515-54": ECS_AN515_46,
+    "Nitro AN515-55": ECS_AN515_46,
     "Nitro AN515-56": ECS_AN515_46,
     "Nitro AN515-44": ECS_AN515_44,
     "Nitro AN515-57": ECS_AN515_46,


### PR DESCRIPTION
## Summary

Adds support for the Acer Nitro AN515-55 by mapping it to `ECS_AN515_46`.

## Tested

- Device detection works.
- CPU/GPU temperature readings work.
- Fan RPM readings work.
- Manual fan control works.
- Max Speed works.

Tested on an Acer Nitro AN515-55.